### PR TITLE
Add package.json and eslint code style checker

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,31 @@
+{
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "$": true,
+    "CitySDK": true
+  },
+  "rules": {
+    "camelcase": [0],
+    "comma-spacing": [0],
+    "consistent-return": [0],
+    "curly": [0],
+    "eol-last": [0],
+    "max-len": [1, 360],
+    "key-spacing": [0],
+    "new-cap": [0],
+    "no-mixed-requires": [0],
+    "no-redeclare": [2],
+    "no-underscore-dangle": [0],
+    "no-use-before-define": [0],
+    "no-unused-expressions": [0],
+    "no-extra-semi": [0],
+    "semi": [0],
+    "space-infix-ops": [0],
+    "quotes": [0],
+    "strict": [0],
+    "eqeqeq": [0],
+    "valid-typeof": 2
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "citysdk",
+  "version": "1.0.0",
+  "description": "User-Friendly JavaScript SDK for US Census Bureau Data",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "eslint --no-eslintrc -c .eslintrc js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uscensusbureau/citysdk.git"
+  },
+  "keywords": [
+    "citysdk",
+    "us",
+    "census",
+    "bureau",
+    "api",
+    "maps",
+    "geo"
+  ],
+  "author": "US Census",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/uscensusbureau/citysdk/issues"
+  },
+  "homepage": "https://github.com/uscensusbureau/citysdk",
+  "devDependencies": {
+    "eslint": "^0.24.1"
+  }
+}


### PR DESCRIPTION
I've adjusted the eslint rules to pass on most of the source in js,
but js/citysdk.census.js has quite a few deeper issues that need
consideration - minified terraformer as well as logic issues like
implicit globals, a console.log, and duplicate keys in arrays.

Including terraformer with `require()` would make this file much
more compact as well as exclude a terraformer build from static
analysis.