### PR TITLE
Removing a duplicate record from the aliases hash

### DIFF
--- a/js/citysdk.census.js
+++ b/js/citysdk.census.js
@@ -776,7 +776,7 @@ CensusModule.prototype.aliases = {
     "education_professional": {
         "api": "acs",
         "variable": "B15003_024E",
-        "description": "The number of persons age 25 and over who hold a Profesisonal degree"
+        "description": "The number of persons age 25 and over who hold a Professional degree"
     },
     "education_doctorate": {
         "api": "acs",

--- a/js/citysdk.census.js
+++ b/js/citysdk.census.js
@@ -676,11 +676,6 @@ CensusModule.prototype.aliases = {
         "variable": "B02001_008E",
         "description": "Population (Two or more races)"
     },
-    "population_native_hawaiian_alone": {
-        "api": "acs",
-        "variable": "B02001_006E",
-        "description": "Population (Native Hawaiian and Other Pacific Islander Alone)"
-    },
     "population_hispanic_origin": {
         "api": "acs",
         "variable": "B03001_003E",


### PR DESCRIPTION
The `"population_native_hawaiian_alone"` field was listed twice in the aliases for the Census module. This PR removes the dupe.

Also fixed a spelling error in one of the ACS field descriptions.