### PR TITLE
Update index.html

### DIFF
--- a/showcase/index.html
+++ b/showcase/index.html
@@ -73,7 +73,7 @@
         <p>The goal of the City SDK project is to streamline the creation of open data apps for cities. The areas of focus are: helper functions, GeoJSON support, interoperability, visualization, and open-source.</p>
         <p><a class="btn btn-primary btn-lg" href="http://uscensusbureau.github.io/citysdk/index.html" role="button">Learn more about CitySDK &raquo;</a></p>
         <p>This page is a showcase of current features. You'll need a Census API key to fully enjoy our samples.</p>
-        <p>You can get one <a href="http://www.census.gov/developers/" target="_blank">here</a>, and when you have one, enter it <a href="#" onclick="getApiKey()">here!</a></p>
+        <p>You can get one <a href="http://api.census.gov/data/key_signup.html" target="_blank">here</a>, and when you have one, enter it <a href="#" onclick="getApiKey()">here!</a></p>
     </div>
 </div>
 


### PR DESCRIPTION
Link to request an API key goes to the census developer page instead of to the API Key sign up page. It would be more convenient to go directly to the signup page.