### PR TITLE
Fixed URL to CivicData

### DIFF
--- a/examples/permitDataCKAN/index.html
+++ b/examples/permitDataCKAN/index.html
@@ -294,7 +294,7 @@ title: Building Permits with BLDS & CKAN
     ckan.enable();
 
     // Set the server to pull data from
-    ckan.<var>DEFAULT_ENDPOINTS.apiURL</var> = "https://www.civicdata.com/api/3/action/";
+    ckan.<var>DEFAULT_ENDPOINTS.apiURL</var> = "http://www.civicdata.com/api/3/action/";
 
 	var <var>request</var> = <var id="codeDemoRequestedSeriesID"></var>;
 


### PR DESCRIPTION
CivicData.com is currently only served via HTTP. This change fixes the example using BLDS data.