### PR TITLE
Fixed broken ESRItoGEO function

### DIFF
--- a/js/core/README.md
+++ b/js/core/README.md
@@ -1,0 +1,25 @@
+# CitySDK Core
+
+### Dependencies
+1. Terraformer
+2. ArcGIS Parser
+
+Install using Bower
+
+```
+bower install
+```
+
+Or, install using NPM
+
+```
+npm install
+```
+
+Or, when using it in the browser
+
+```
+<script src="http://cdn-geoweb.s3.amazonaws.com/terraformer/1.0.5/terraformer.min.js"></script>
+<script src="http://cdn-geoweb.s3.amazonaws.com/terraformer-arcgis-parser/1.0.4/terraformer-arcgis-parser.min.js"></script>
+<script src="https://cdn.rawgit.com/uscensusbureau/citysdk/Release1.1/js/citysdk.js"></script>
+```


### PR DESCRIPTION
The argument name was being used. This was probably just a type. It's now fixed.