### PR TITLE
docs(README): corrected last CSJ version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Starting with v2.3.0, CitySDK ships as an ESM export
 Migration:
 
 ```js
-// 2.2.x or below
+// 2.2.5 or below
 const census = require('citysdk')
 // 2.3.x or above
 import census from 'citysdk'


### PR DESCRIPTION
## Summary

Currently the README states that the CJS (CommonJS) version of the package is available in versions "2.2.x or below" however from my testing the last CSJ version is actually `2.2.5`. `2.2.6` and up are ESM.